### PR TITLE
Add unit tests for config, data, and training helpers

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+# Prepare path to src
+SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_model_config(monkeypatch):
+    # Fake transformers module with EsmConfig
+    class FakeEsmConfig(SimpleNamespace):
+        @classmethod
+        def from_dict(cls, d):
+            return cls(**d)
+
+    fake_transformers = SimpleNamespace(EsmConfig=FakeEsmConfig)
+    monkeypatch.setitem(sys.modules, 'transformers', fake_transformers)
+
+    config = load_module('config', SRC_DIR / 'config.py')
+    model_cfg = config.get_model_config()
+
+    assert model_cfg.model_name == 'facebook/esm2_t30_150M_UR50D'
+    assert model_cfg.num_layers == 30
+
+
+def test_get_training_and_data_config(monkeypatch):
+    # Patch transformers again for EsmConfig import during module load
+    class FakeEsmConfig(SimpleNamespace):
+        @classmethod
+        def from_dict(cls, d):
+            return cls(**d)
+
+    monkeypatch.setitem(sys.modules, 'transformers', SimpleNamespace(EsmConfig=FakeEsmConfig))
+    config = load_module('config', SRC_DIR / 'config.py')
+
+    training_cfg = config.get_training_config()
+    data_cfg = config.get_data_config()
+
+    assert 'learning_rate' in training_cfg
+    assert 'chunk_size' in data_cfg

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -1,0 +1,51 @@
+import torch
+from src import custom_model
+
+
+class DummyAttention(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.query = torch.nn.Linear(4, 4)
+        self.key = torch.nn.Linear(4, 4)
+        self.value = torch.nn.Linear(4, 4)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attn = DummyAttention()
+        self.fc = torch.nn.Linear(4, 4)
+        self.norm = torch.nn.LayerNorm(4)
+
+    def forward(self, input_ids, attention_mask=None):
+        batch, length = input_ids.shape
+        logits = torch.zeros(batch, length, 2)
+        return {"logits": logits}
+
+
+def test_remove_bias_from_attention_linear_layernorm():
+    model = DummyModel()
+    assert model.attn.query.bias is not None
+    assert model.fc.bias is not None
+    assert model.norm.bias is not None
+
+    custom_model.remove_bias_from_attention_linear_layernorm(model)
+
+    assert model.attn.query.bias is None
+    assert model.attn.key.bias is None
+    assert model.attn.value.bias is None
+    assert model.fc.bias is None
+    assert model.norm.bias is None
+
+
+def test_add_loss_to_forward():
+    model = DummyModel()
+    custom_model.add_loss_to_forward(model)
+
+    input_ids = torch.tensor([[1, 1]])
+    labels = torch.tensor([[1, -100]])
+    outputs = model(input_ids=input_ids, labels=labels)
+
+    assert "loss" in outputs
+    loss_val = outputs["loss"].item()
+    assert loss_val >= 0

--- a/tests/test_custom_trainer.py
+++ b/tests/test_custom_trainer.py
@@ -1,0 +1,24 @@
+from src.custom_trainer import CustomTrainer
+
+
+def test_group_by_batch():
+    dataset = [
+        {"batch_id": 0, "val": 1},
+        {"batch_id": 0, "val": 2},
+        {"batch_id": 1, "val": 3},
+    ]
+    trainer = CustomTrainer.__new__(CustomTrainer)
+    groups = trainer.group_by_batch(dataset)
+    assert len(groups) == 2
+    assert sorted(len(g) for g in groups) == [1, 2]
+
+
+def test_create_collate_fn_removes_keys():
+    def base_collate(batch):
+        return batch
+
+    collate = CustomTrainer.create_collate_fn(base_collate, keys_to_remove=["id"]) 
+    batch = [[{"id": 1, "x": 2}, {"id": 2, "x": 3}]]
+    result = collate(batch)
+    assert all("id" not in ex for ex in result)
+    assert result[0]["x"] == 2

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,31 @@
+from src import data_processing
+
+
+def test_pad_batch_basic():
+    batch = [
+        {"input_ids": [1, 2], "attention_mask": [1, 1], "labels": [5, 6]},
+        {"input_ids": [3], "attention_mask": [1], "labels": [7]},
+    ]
+    padded = data_processing.pad_batch(batch, max_length=3, pad_token_id=0)
+    for ex in padded:
+        assert len(ex["input_ids"]) == 3
+        assert len(ex["attention_mask"]) == 3
+        assert len(ex["labels"]) == 3
+    assert padded[1]["input_ids"] == [3, 0, 0]
+    assert padded[1]["labels"][-1] == -100
+
+
+def test_refine_fasta(tmp_path):
+    fasta = tmp_path / "input.fasta"
+    fasta.write_text(
+        ">seq1\nABCDE\n>seq2\nABCDEFG\n>seq1\nXYZ\n>seq3\nABC\n"
+    )
+    output = tmp_path / "refined.fasta"
+    result = data_processing.refine_fasta(str(fasta), str(output), max_length=5)
+    assert ">seq1" in result and result[">seq1"] == "ABCDE"
+    assert ">seq3" in result and result[">seq3"] == "ABC"
+    assert ">seq2" not in result  # too long
+    assert output.exists()
+    text = output.read_text()
+    assert ">seq2" not in text
+    assert text.count("seq1") == 1


### PR DESCRIPTION
## Summary
- add tests for configuration loader
- add tests for data preprocessing helpers
- add unit tests for `custom_model` and `custom_trainer`

## Testing
- `pip install pytest` *(fails: no network access)*
- `pytest -q` *(fails: command not found)*