### PR TITLE
Add perplexity metrics for training and validation

### DIFF
--- a/tests/test_custom_trainer.py
+++ b/tests/test_custom_trainer.py
@@ -22,3 +22,30 @@ def test_create_collate_fn_removes_keys():
     result = collate(batch)
     assert all("id" not in ex for ex in result)
     assert result[0]["x"] == 2
+
+def test_evaluate_returns_perplexities():
+    import torch
+    from types import SimpleNamespace
+    from datasets import Dataset
+
+    sample = {"batch_id": 0, "input_ids": [1], "attention_mask": [1], "labels": [1]}
+    ds = Dataset.from_list([sample])
+
+    trainer = CustomTrainer.__new__(CustomTrainer)
+    trainer.train_dataset = ds
+    trainer.eval_dataset = ds
+    trainer.data_collator = lambda batch: {
+        "input_ids": torch.tensor([ex["input_ids"] for ex in batch]),
+        "attention_mask": torch.tensor([ex["attention_mask"] for ex in batch]),
+        "labels": torch.tensor([ex["labels"] for ex in batch]),
+    }
+    trainer.args = SimpleNamespace(dataloader_num_workers=0, device=torch.device("cpu"))
+    trainer.log = lambda metrics: None
+    trainer.model = torch.nn.Module()
+    def forward(input_ids, attention_mask=None, labels=None):
+        return {"loss": torch.tensor(0.0)}
+    trainer.model.forward = forward
+
+    metrics = CustomTrainer.evaluate(trainer)
+    assert "eval_perplexity" in metrics
+    assert "train_perplexity" in metrics


### PR DESCRIPTION
## Summary
- compute perplexity for both training and validation datasets during evaluation
- expose helper methods on trainer to evaluate whole training dataset
- cover new evaluate behaviour with unit test

## Testing
- `pip install pytest` *(fails: Could not find a version)*