### PR TITLE
Add tests for Muon optimizer

### DIFF
--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -1,5 +1,6 @@
 import torch
 from src import custom_model
+import types
 
 
 class DummyAttention(torch.nn.Module):
@@ -49,3 +50,52 @@ def test_add_loss_to_forward():
     assert "loss" in outputs
     loss_val = outputs["loss"].item()
     assert loss_val >= 0
+
+
+def test_initialize_model_zero_init(monkeypatch):
+    class DummyAutoTokenizer:
+        @staticmethod
+        def from_pretrained(name):
+            return "tokenizer"
+
+    class DummyAutoConfig:
+        @staticmethod
+        def from_pretrained(name):
+            return types.SimpleNamespace()
+
+    class DummyModel(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.lm_head = torch.nn.Linear(2, 2)
+            self.classifier = torch.nn.Linear(2, 2)
+            self.proj_out = torch.nn.Linear(2, 2)
+            self.output_layer = torch.nn.Linear(2, 2)
+            self.embed_out = torch.nn.Linear(2, 2)
+
+    def fake_get_model_config():
+        return types.SimpleNamespace(
+            model_name="dummy",
+            max_position_embeddings=2,
+            max_batch_size=2,
+            use_fa=False,
+            emb_layer_norm_before=False,
+            num_layers=1,
+            hidden_size=2,
+            intermediate_size=2,
+            num_attention_heads=1,
+        )
+
+    monkeypatch.setattr(custom_model, "AutoTokenizer", DummyAutoTokenizer)
+    monkeypatch.setattr(custom_model, "AutoConfig", DummyAutoConfig)
+    monkeypatch.setattr(custom_model, "FAEsmForMaskedLM", DummyModel)
+    monkeypatch.setattr(custom_model, "get_model_config", fake_get_model_config)
+    monkeypatch.setattr(custom_model, "remove_bias_from_attention_linear_layernorm", lambda m: m)
+    monkeypatch.setattr(custom_model, "add_loss_to_forward", lambda m: m)
+
+    model, tok = custom_model.initialize_model_and_tokenizer()
+
+    for attr in ["lm_head", "classifier", "proj_out", "output_layer", "embed_out"]:
+        layer = getattr(model, attr)
+        assert torch.allclose(layer.weight, torch.zeros_like(layer.weight))
+        if layer.bias is not None:
+            assert torch.allclose(layer.bias, torch.zeros_like(layer.bias))

--- a/tests/test_custom_trainer.py
+++ b/tests/test_custom_trainer.py
@@ -1,4 +1,6 @@
 from src.custom_trainer import CustomTrainer
+import torch
+import types
 
 
 def test_group_by_batch():
@@ -22,3 +24,21 @@ def test_create_collate_fn_removes_keys():
     result = collate(batch)
     assert all("id" not in ex for ex in result)
     assert result[0]["x"] == 2
+
+
+def test_create_optimizer_muon():
+    model = torch.nn.Linear(1, 1)
+    trainer = CustomTrainer.__new__(CustomTrainer)
+    trainer.model = model
+    trainer.args = types.SimpleNamespace(learning_rate=0.1)
+    trainer.gradient_clipping = None
+    trainer.optimizer = None
+    trainer.optimizer_config = {"type": "muon", "beta_1": 0.8, "beta_2": 0.7, "epsilon": 0.0, "weight_decay": 0.0}
+    trainer.beta_1 = 0.8
+    trainer.beta_2 = 0.7
+    trainer.epsilon = 0.0
+    trainer.weight_decay = 0.0
+
+    opt = trainer.create_optimizer()
+    from src.muon import Muon
+    assert isinstance(opt, Muon)

--- a/tests/test_muon_optimizer.py
+++ b/tests/test_muon_optimizer.py
@@ -1,0 +1,10 @@
+import torch
+from src.muon import Muon
+
+
+def test_muon_optimizer_step_basic():
+    param = torch.nn.Parameter(torch.tensor([1.0]))
+    opt = Muon([param], lr=0.1, beta1=0.0, beta2=0.0, eps=0.0, weight_decay=0.0)
+    param.grad = torch.tensor([2.0])
+    opt.step()
+    assert torch.allclose(param, torch.tensor([0.9]))


### PR DESCRIPTION
## Summary
- create new unit test for Muon optimizer step
- ensure initialize_model_and_tokenizer zeros out projection layers
- verify that CustomTrainer creates the Muon optimizer when configured

## Testing
- `pytest -q` *(fails: command not found)*